### PR TITLE
Adding support for sub-folder in Arlifile

### DIFF
--- a/lib/arli/actions/action.rb
+++ b/lib/arli/actions/action.rb
@@ -13,9 +13,12 @@ module Arli
       extend Forwardable
       def_delegators :@library,
                      :exists?,
-                     :path, :temp_path,
-                     :dir, :temp_dir,
-                     :libraries_home
+                     :path,
+                     :temp_path,
+                     :dir,
+                     :temp_dir,
+                     :libraries_home,
+                     :folder
 
       class << self
         def inherited(base)

--- a/lib/arli/actions/move_to_library_path.rb
+++ b/lib/arli/actions/move_to_library_path.rb
@@ -15,7 +15,12 @@ module Arli
           if Dir.exist?(temp_path) && !Dir.exist?(path)
             FileUtils.mkdir_p(File.dirname(path))
             ___ "current: #{Dir.pwd.yellow}\ntemp_path: #{temp_path.yellow}\nlibrary_path: #{path.yellow}\n" if debug?
-            mv(temp_path, path)
+            if folder && Dir.exist?("#{temp_path}/#{folder}")
+              mv("#{temp_path}/#{folder}", path)
+              FileUtils.rm_rf(temp_path)
+            else
+              mv(temp_path, path)
+            end
           elsif Dir.exist?(path)
             raise ::Arli::Errors::InstallerError,
                   "Directory #{path} was not expected to still be there!"

--- a/lib/arli/commands/install.rb
+++ b/lib/arli/commands/install.rb
@@ -12,6 +12,7 @@ module Arli
   module Commands
     class Install < Base
       require 'arduino/library/include'
+      include Arduino::Library::InstanceMethods
 
       attr_accessor :library,
                     :arlifile,
@@ -47,22 +48,24 @@ module Arli
       def identify_library(arg)
         results = if arg =~ %r[https?://]i
                     self.install_method = :url
-                    r                   = search(url: /^#{arg}$/i)
-                    if r.empty?
+                    result = search url: /^#{arg}$/i
+
+                    if result.empty?
                       self.install_method = :website
-                      r                   = search(website: /^#{arg}$/i)
+                      result = search(website: /^#{arg}$/i)
                     end
-                    if r.empty?
+
+                    if result.empty?
                       self.install_method = :custom
-                      r                   = [Arduino::Library::Model.from_hash(url: arg, name: File.basename(arg))]
+                      result = [Arduino::Library::Model.from_hash(url: arg, name: File.basename(arg))]
                     end
-                    r
+                    result
                   elsif File.exist?(arg) || arg =~ /\.zip$/
                     self.install_method = :archiveFileName
-                    search(archiveFileName: "#{File.basename(arg)}")
+                    search archiveFileName: "#{File.basename(arg)}"
                   else
                     self.install_method = :name
-                    search(name: /^#{arg}$/)
+                    search name: /^#{arg}$/
                   end
 
         validate_search(arg, results)
@@ -75,6 +78,11 @@ module Arli
 
       def post_install
         #
+      end
+
+      def search(**opts)
+        # noinspection RubyArgCount
+        super(opts)
       end
 
       private

--- a/lib/arli/helpers/inherited.rb
+++ b/lib/arli/helpers/inherited.rb
@@ -36,6 +36,7 @@ module Arli
       end
 
       def self.included(base)
+        # This works for both classes and modules
         base.instance_eval do
           class << self
             include(::Arli::Helpers::Inherited::ClassMethods)

--- a/lib/arli/library.rb
+++ b/lib/arli/library.rb
@@ -5,7 +5,7 @@ require 'arli/errors'
 
 module Arli
   module Library
-    ADDITIONAL_KEYS = %i(depends headers_only)
+    ADDITIONAL_KEYS = %i(depends headers_only folder)
 
     def library_model(lib)
       return lib if lib.is_a?(::Arduino::Library::Model)

--- a/lib/arli/library/single_version.rb
+++ b/lib/arli/library/single_version.rb
@@ -16,7 +16,8 @@ module Arli
 
       # Additional attributes that can be set via Arlifile
       attr_accessor :headers_only,
-                    :depends
+                    :depends,
+                    :folder # indicates a sub-folder of the library
 
       def initialize(lib, config: Arli.config)
         self.lib          = lib
@@ -24,6 +25,7 @@ module Arli
         self.lib_dir      = lib.name.gsub(/ /, '_')
         self.headers_only = false
         self.depends      = nil
+        self.folder       = nil
       end
 
       def install

--- a/lib/arli/version.rb
+++ b/lib/arli/version.rb
@@ -1,3 +1,3 @@
 module Arli
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
This PR adds `folder` element for each library defined in the Arlifile. If defined, that folder relative to the root will be installed as the library, and the rest removed.